### PR TITLE
Bump upper version limit for the stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,14 @@
+# This file can be used to install module dependencies for unit testing
+# See https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures for details
+---
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.13.1
+      repo: "puppetlabs/stdlib"
     epel:
-      repo: git://github.com/stahnma/puppet-module-epel.git
+      repo: "puppet/epel"
     yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      repo: "puppetlabs/yumrepo_core"
       puppet_version: ">= 6.0.0"
   symlinks:
     munge: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <8.0.0"
+      "version_requirement": ">= 4.13.1 <9.0.0"
     },
     {
       "name": "puppet/epel",


### PR DESCRIPTION
In addition rework fixture file to use forge release when runnign
rspec-puppet tests. This automatically fixes the old repo URL for the
EPEL module, which still pointed to the old stahnma repo. No error
occured previsouly as this URL was redirect to the version in org
voxpupuli, where it officially lives now.
