### PR TITLE
Add package_install_options to the package resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,8 @@
 #   Shell of munge user
 # @param munge_user_home
 #   Home directory of munge user
+# @param package_install_options
+#   An array of additional options to pass when installing a package. Typical usage is enabling certain repositories like EPEL.
 #
 class munge (
   Boolean $manage_repo                  = true,
@@ -80,6 +82,7 @@ class munge (
   Optional[Integer] $munge_group_gid    = undef,
   Stdlib::Absolutepath $munge_user_shell = '/sbin/nologin',
   Stdlib::Absolutepath $munge_user_home = '/var/run/munge',
+  Optional[Array[String]] $package_install_options = undef,
 ) {
 
   if ! $facts['os']['family'] in ['RedHat'] {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,9 @@
 class munge::install {
 
   package { 'munge':
-    ensure => $::munge::package_ensure,
-    name   => $::munge::package_name,
+    ensure          => $::munge::package_ensure,
+    name            => $::munge::package_name,
+    install_options => $::munge::package_install_options,
   }
 
   if $::munge::install_dev {


### PR DESCRIPTION
Add the possibility to pass additional options when installing a
package. Typical usage is enabling certain repos that are disabled by
default e.g. `--enablerepo=epel`.